### PR TITLE
Fix  add groups page scroll behavior

### DIFF
--- a/pages/SelectGroup.js
+++ b/pages/SelectGroup.js
@@ -98,7 +98,10 @@ function GroupListScreen({ navigation }) {
 
 const styles = StyleSheet.create({
     container: {
+        flex: 1,
         alignItems: 'center',
+        display: 'flex',
+        flexDirection: 'column',
     },
     header: {
         fontSize: getFontSizeByWindowWidth(19),
@@ -130,7 +133,7 @@ const styles = StyleSheet.create({
         color: 'white',
     },
     list: {
-        height: calcHeight(100),
+        flex: 1,
     },
 });
 


### PR DESCRIPTION
## Before:

- The group list did not occupy the full height.
- The scrollbar made the layout look weird.
## Now:

- It takes up the full screen.
- The scrollbar has been removed.