### PR TITLE
Fixed group balance color condition

### DIFF
--- a/components/GroupBalanceCard.js
+++ b/components/GroupBalanceCard.js
@@ -64,7 +64,7 @@ function GroupBalanceCard({ group, loading }) {
                 <View style={styles.textContainer}>
                     <Text style={styles.nameText}>{sliceText(group.name, 20)}</Text>
                     <Text style={styles.memberText}>
-                        {group.totalBalance < 0
+                        {group.totalBalance > 0
                             ? `${group.lenderCount} participants owe you money`
                             : `You owe money to ${group.borrowerCount} participants`}
                     </Text>


### PR DESCRIPTION
Before:
- If group.totalBalance < 0, it showed how many people the user owes money to, and the text color was green.

After:
The logic and color have been reversed:
- If group.totalBalance > 0, it now shows how many people owe money to the user, and the text color is green.
- If group.totalBalance <= 0, it shows how many people the user owes money to, and the text color is red.
