### PR TITLE
Fix: Prevent 0 value in amount input and enforce mandatory transaction description

### DIFF
--- a/pages/TransactionForm.js
+++ b/pages/TransactionForm.js
@@ -79,8 +79,12 @@ function TransactionFormScreen({ navigation, route }) {
     const remainingCharacters = transactionData && transactionData.description ? 100 - transactionData.description.length : 100;
 
     const handleSubmit = async () => {
-        if (!transactionData.amount) {
+        if (!transactionData.amount || transactionData.amount == 0) {
             Alert.alert('Amount Missing');
+            return;
+        }
+        if (!transactionData.description || transactionData.description == '' || transactionData.description === undefined) {
+            Alert.alert('Description Missing');
             return;
         }
 


### PR DESCRIPTION
# Before
-  Amount input accepts 0 value, and transactions can be added without a description
# Now
- Fixed the bug by adding if condition