### PR TITLE
Fixed zero participant bug in balance screen

### DIFF
--- a/components/GroupBalanceCard.js
+++ b/components/GroupBalanceCard.js
@@ -65,8 +65,8 @@ function GroupBalanceCard({ group, loading }) {
                     <Text style={styles.nameText}>{sliceText(group.name, 20)}</Text>
                     <Text style={styles.memberText}>
                         {group.totalBalance > 0
-                            ? `${group.lenderCount} participants owe you money`
-                            : `You owe money to ${group.borrowerCount} participants`}
+                            ? `${group.borrowerCount} participants owe you money`
+                            : `You owe money to ${group.lenderCount} participants`}
                     </Text>
                 </View>
             </View>


### PR DESCRIPTION
# Before
- The number of participants on the Balance screen was not being displayed properly

# Now
- fixed the bug by using appropriate variable 